### PR TITLE
Code cleanup

### DIFF
--- a/api/src/main/java/com/buschmais/cdo/api/bootstrap/CdoUnit.java
+++ b/api/src/main/java/com/buschmais/cdo/api/bootstrap/CdoUnit.java
@@ -16,21 +16,21 @@ import java.util.Set;
  */
 public class CdoUnit {
 
-    private String name;
+    private final String name;
 
-    private String description;
+    private final String description;
 
-    private URI uri;
+    private final URI uri;
 
-    private Class<?> provider;
+    private final Class<?> provider;
 
-    private Set<Class<?>> types;
+    private final Set<Class<?>> types;
 
-    private ValidationMode validationMode;
+    private final ValidationMode validationMode;
 
-    private TransactionAttribute defaultTransactionAttribute;
+    private final TransactionAttribute defaultTransactionAttribute;
 
-    private Properties properties;
+    private final Properties properties;
 
     public CdoUnit(String name, String description, URI uri, Class<?> provider, Set<Class<?>> types, ValidationMode validationMode, TransactionAttribute defaultTransactionAttribute, Properties properties) {
         this.name = name;

--- a/impl/src/main/java/com/buschmais/cdo/impl/CdoTransactionImpl.java
+++ b/impl/src/main/java/com/buschmais/cdo/impl/CdoTransactionImpl.java
@@ -7,10 +7,10 @@ import java.util.*;
 
 public class CdoTransactionImpl implements CdoTransaction {
 
-    private DatastoreTransaction datastoreTransaction;
+    private final DatastoreTransaction datastoreTransaction;
 
-    private List<Synchronization> defaultSynchronizations = new ArrayList<>();
-    private List<Synchronization> synchronizations = new ArrayList<>();
+    private final List<Synchronization> defaultSynchronizations = new ArrayList<>();
+    private final List<Synchronization> synchronizations = new ArrayList<>();
 
     public CdoTransactionImpl(DatastoreTransaction datastoreTransaction) {
         this.datastoreTransaction = datastoreTransaction;

--- a/impl/src/main/java/com/buschmais/cdo/impl/bootstrap/CdoBootstrapServiceImpl.java
+++ b/impl/src/main/java/com/buschmais/cdo/impl/bootstrap/CdoBootstrapServiceImpl.java
@@ -12,7 +12,7 @@ import java.util.*;
 
 public class CdoBootstrapServiceImpl implements CdoBootstrapService {
 
-    private CdoUnitFactory cdoUnitFactory = CdoUnitFactory.getInstance();
+    private final CdoUnitFactory cdoUnitFactory = CdoUnitFactory.getInstance();
 
     private Map<String, CdoUnit> cdoUnits;
 

--- a/impl/src/main/java/com/buschmais/cdo/impl/bootstrap/CdoUnitFactory.java
+++ b/impl/src/main/java/com/buschmais/cdo/impl/bootstrap/CdoUnitFactory.java
@@ -27,8 +27,8 @@ public class CdoUnitFactory {
 
     private static final CdoUnitFactory instance = new CdoUnitFactory();
 
-    private JAXBContext cdoContext;
-    private Schema cdoXsd;
+    private final JAXBContext cdoContext;
+    private final Schema cdoXsd;
 
     private CdoUnitFactory() {
         try {

--- a/impl/src/main/java/com/buschmais/cdo/impl/bootstrap/CdoUnitValidationHandler.java
+++ b/impl/src/main/java/com/buschmais/cdo/impl/bootstrap/CdoUnitValidationHandler.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public class CdoUnitValidationHandler implements ValidationEventHandler {
 
-    private List<String> errorMessages = new ArrayList<>();
+    private final List<String> errorMessages = new ArrayList<>();
 
     @Override
     public boolean handleEvent(ValidationEvent event) {

--- a/impl/src/main/java/com/buschmais/cdo/impl/bootstrap/osgi/CdoUnitBundleListener.java
+++ b/impl/src/main/java/com/buschmais/cdo/impl/bootstrap/osgi/CdoUnitBundleListener.java
@@ -18,7 +18,7 @@ public class CdoUnitBundleListener implements BundleActivator, BundleListener {
     private static final Logger LOGGER = LoggerFactory
             .getLogger(CdoUnitBundleListener.class);
 
-    private Map<Long, List<CdoManagerFactory>> registeredCdoManagerFactories = new HashMap<>();
+    private final Map<Long, List<CdoManagerFactory>> registeredCdoManagerFactories = new HashMap<>();
 
     @Override
     public void start(BundleContext context) throws Exception {

--- a/impl/src/main/java/com/buschmais/cdo/impl/cache/AbstractCache.java
+++ b/impl/src/main/java/com/buschmais/cdo/impl/cache/AbstractCache.java
@@ -5,7 +5,7 @@ import java.util.Map;
 
 public abstract class AbstractCache<Key, Value> implements Cache<Key, Value> {
 
-    private Map<Key, Value> cache;
+    private final Map<Key, Value> cache;
 
     protected AbstractCache(Map<Key, Value> cache) {
         this.cache = cache;

--- a/impl/src/main/java/com/buschmais/cdo/impl/cache/CacheSynchronization.java
+++ b/impl/src/main/java/com/buschmais/cdo/impl/cache/CacheSynchronization.java
@@ -8,11 +8,11 @@ import java.util.Collection;
 
 public class CacheSynchronization<Entity> implements CdoTransaction.Synchronization {
 
-    private InstanceManager<?, Entity> instanceManager;
+    private final InstanceManager<?, Entity> instanceManager;
 
-    private TransactionalCache<?> transactionalCache;
+    private final TransactionalCache<?> transactionalCache;
 
-    private DatastoreSession<?, Entity, ?, ?, ?, ?> datastoreSession;
+    private final DatastoreSession<?, Entity, ?, ?, ?, ?> datastoreSession;
 
     public CacheSynchronization(InstanceManager<?, Entity> instanceManager, TransactionalCache<?> transactionalCache, DatastoreSession<?, Entity, ?, ?, ?, ?> datastoreSession) {
         this.instanceManager = instanceManager;

--- a/impl/src/main/java/com/buschmais/cdo/impl/interceptor/AbstractCdoInterceptor.java
+++ b/impl/src/main/java/com/buschmais/cdo/impl/interceptor/AbstractCdoInterceptor.java
@@ -2,7 +2,7 @@ package com.buschmais.cdo.impl.interceptor;
 
 public abstract class AbstractCdoInterceptor<T> implements CdoInterceptor<T> {
 
-    private T delegate;
+    private final T delegate;
 
     public AbstractCdoInterceptor(T delegate) {
         this.delegate = delegate;

--- a/impl/src/main/java/com/buschmais/cdo/impl/interceptor/InterceptorFactory.java
+++ b/impl/src/main/java/com/buschmais/cdo/impl/interceptor/InterceptorFactory.java
@@ -10,8 +10,8 @@ import java.util.Arrays;
 
 public class InterceptorFactory {
 
-    private CdoTransaction cdoTransaction;
-    private TransactionAttribute transactionAttribute;
+    private final CdoTransaction cdoTransaction;
+    private final TransactionAttribute transactionAttribute;
 
     public InterceptorFactory(CdoTransaction cdoTransaction, TransactionAttribute transactionAttribute) {
         this.cdoTransaction = cdoTransaction;

--- a/impl/src/main/java/com/buschmais/cdo/impl/interceptor/TransactionInterceptor.java
+++ b/impl/src/main/java/com/buschmais/cdo/impl/interceptor/TransactionInterceptor.java
@@ -10,9 +10,9 @@ import java.lang.reflect.Method;
 
 public class TransactionInterceptor<T> extends AbstractCdoInterceptor<T> {
 
-    private CdoTransaction cdoTransaction;
+    private final CdoTransaction cdoTransaction;
 
-    private TransactionAttribute defaultTransactionAttribute;
+    private final TransactionAttribute defaultTransactionAttribute;
 
     public TransactionInterceptor(T delegate, CdoTransaction cdoTransaction, TransactionAttribute defaultTransactionAttribute) {
         super(delegate);

--- a/impl/src/main/java/com/buschmais/cdo/impl/metadata/DependencyResolver.java
+++ b/impl/src/main/java/com/buschmais/cdo/impl/metadata/DependencyResolver.java
@@ -5,8 +5,8 @@ import java.util.*;
 public class DependencyResolver<T> {
 
     private Map<T, Set<T>> blockedBy;
-    private Collection<T> elements;
-    private DependencyProvider<T> dependencyProvider;
+    private final Collection<T> elements;
+    private final DependencyProvider<T> dependencyProvider;
 
     private DependencyResolver(Collection<T> elements, DependencyProvider<T> dependencyProvider) {
         this.elements = elements;

--- a/impl/src/main/java/com/buschmais/cdo/impl/metadata/MetadataProviderImpl.java
+++ b/impl/src/main/java/com/buschmais/cdo/impl/metadata/MetadataProviderImpl.java
@@ -27,10 +27,10 @@ import java.util.*;
 public class MetadataProviderImpl<EntityMetadata extends DatastoreEntityMetadata<Discriminator>, Discriminator> implements MetadataProvider<EntityMetadata, Discriminator> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TypeMetadata.class);
-    private DatastoreMetadataFactory<EntityMetadata, Discriminator> metadataFactory;
-    private TypeMetadataResolver<EntityMetadata, Discriminator> typeMetadataResolver;
+    private final DatastoreMetadataFactory<EntityMetadata, Discriminator> metadataFactory;
+    private final TypeMetadataResolver<EntityMetadata, Discriminator> typeMetadataResolver;
 
-    private Map<Class<?>, TypeMetadata<EntityMetadata>> entityMetadataByType = new HashMap<>();
+    private final Map<Class<?>, TypeMetadata<EntityMetadata>> entityMetadataByType = new HashMap<>();
 
     public MetadataProviderImpl(Collection<Class<?>> types, Datastore<?, EntityMetadata, Discriminator> datastore) {
         this.metadataFactory = datastore.getMetadataFactory();

--- a/impl/src/main/java/com/buschmais/cdo/impl/metadata/TypeMetadataResolver.java
+++ b/impl/src/main/java/com/buschmais/cdo/impl/metadata/TypeMetadataResolver.java
@@ -18,9 +18,8 @@ public class TypeMetadataResolver<EntityMetadata extends DatastoreEntityMetadata
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TypeMetadataResolver.class);
 
-    private Map<Class<?>, TypeMetadata<EntityMetadata>> metadataByType;
-    private Map<TypeMetadata<EntityMetadata>, Set<Discriminator>> aggregatedDiscriminators = new HashMap<>();
-    private Map<Discriminator, Set<TypeMetadata<EntityMetadata>>> typeMetadataByDiscriminator = new HashMap<>();
+    private final Map<TypeMetadata<EntityMetadata>, Set<Discriminator>> aggregatedDiscriminators = new HashMap<>();
+    private final Map<Discriminator, Set<TypeMetadata<EntityMetadata>>> typeMetadataByDiscriminator = new HashMap<>();
 
     /**
      * Constructor.
@@ -29,7 +28,6 @@ public class TypeMetadataResolver<EntityMetadata extends DatastoreEntityMetadata
      */
     public TypeMetadataResolver(Map<Class<?>, TypeMetadata<EntityMetadata>> metadataByType) {
         LOGGER.debug("Type metadata = '{}'", metadataByType);
-        this.metadataByType = metadataByType;
         for (TypeMetadata typeMetadata : metadataByType.values()) {
             Set<Discriminator> discriminators = getAggregatedDiscriminators(typeMetadata);
             LOGGER.debug("Aggregated discriminators of '{}' = '{}'", typeMetadata, discriminators);

--- a/impl/src/main/java/com/buschmais/cdo/impl/proxy/collection/CollectionProxy.java
+++ b/impl/src/main/java/com/buschmais/cdo/impl/proxy/collection/CollectionProxy.java
@@ -11,12 +11,12 @@ import java.util.Iterator;
 
 public class CollectionProxy<Instance, Entity> extends AbstractCollection<Instance> implements Collection<Instance> {
 
-    private Entity entity;
-    private RelationMetadata metadata;
-    private RelationMetadata.Direction direction;
-    private InstanceManager<?, Entity> instanceManager;
-    private PropertyManager<?, Entity, ?, ?> propertyManager;
-    private InterceptorFactory interceptorFactory;
+    private final Entity entity;
+    private final RelationMetadata metadata;
+    private final RelationMetadata.Direction direction;
+    private final InstanceManager<?, Entity> instanceManager;
+    private final PropertyManager<?, Entity, ?, ?> propertyManager;
+    private final InterceptorFactory interceptorFactory;
 
     public CollectionProxy(Entity entity, RelationMetadata metadata, RelationMetadata.Direction direction, InstanceManager instanceManager, PropertyManager propertyManager, InterceptorFactory interceptorFactory) {
         this.entity = entity;

--- a/impl/src/main/java/com/buschmais/cdo/impl/proxy/collection/ListProxy.java
+++ b/impl/src/main/java/com/buschmais/cdo/impl/proxy/collection/ListProxy.java
@@ -7,7 +7,7 @@ import java.util.ListIterator;
 
 public class ListProxy<Instance> extends AbstractSequentialList<Instance> implements List<Instance> {
 
-    private CollectionProxy<Instance, ?> collectionProxy;
+    private final CollectionProxy<Instance, ?> collectionProxy;
 
     public ListProxy(CollectionProxy<Instance, ?> collectionProxy) {
         this.collectionProxy = collectionProxy;

--- a/impl/src/main/java/com/buschmais/cdo/impl/proxy/collection/SetProxy.java
+++ b/impl/src/main/java/com/buschmais/cdo/impl/proxy/collection/SetProxy.java
@@ -6,7 +6,7 @@ import java.util.Set;
 
 public class SetProxy<T> extends AbstractSet<T> implements Set<T> {
 
-    private CollectionProxy<T, ?> collectionProxy;
+    private final CollectionProxy<T, ?> collectionProxy;
 
     public SetProxy(CollectionProxy<T, ?> collectionProxy) {
         this.collectionProxy = collectionProxy;

--- a/impl/src/main/java/com/buschmais/cdo/impl/proxy/instance/InstanceInvocationHandler.java
+++ b/impl/src/main/java/com/buschmais/cdo/impl/proxy/instance/InstanceInvocationHandler.java
@@ -9,7 +9,7 @@ import java.lang.reflect.Method;
 public class InstanceInvocationHandler<E> implements InvocationHandler {
 
     private E entity;
-    private ProxyMethodService<E, ?> proxyMethodService;
+    private final ProxyMethodService<E, ?> proxyMethodService;
 
     public InstanceInvocationHandler(E entity, ProxyMethodService<E, ?> proxyMethodService) {
         this.entity = entity;

--- a/impl/src/main/java/com/buschmais/cdo/impl/proxy/instance/UnsupportedOperationMethod.java
+++ b/impl/src/main/java/com/buschmais/cdo/impl/proxy/instance/UnsupportedOperationMethod.java
@@ -7,7 +7,7 @@ import java.lang.reflect.Method;
 
 public class UnsupportedOperationMethod<Entity> implements ProxyMethod<Entity> {
 
-    private UnsupportedOperationMethodMetadata methodMetadata;
+    private final UnsupportedOperationMethodMetadata methodMetadata;
 
     public UnsupportedOperationMethod(UnsupportedOperationMethodMetadata methodMetadata) {
         this.methodMetadata = methodMetadata;

--- a/impl/src/main/java/com/buschmais/cdo/impl/proxy/instance/composite/AsMethod.java
+++ b/impl/src/main/java/com/buschmais/cdo/impl/proxy/instance/composite/AsMethod.java
@@ -8,7 +8,7 @@ import java.util.Map;
 
 public class AsMethod<Entity> implements ProxyMethod<Entity> {
 
-    private InstanceManager instanceManager;
+    private final InstanceManager instanceManager;
 
     public AsMethod(InstanceManager instanceManager) {
         this.instanceManager = instanceManager;

--- a/impl/src/main/java/com/buschmais/cdo/impl/proxy/instance/object/EqualsMethod.java
+++ b/impl/src/main/java/com/buschmais/cdo/impl/proxy/instance/object/EqualsMethod.java
@@ -6,9 +6,9 @@ import com.buschmais.cdo.spi.datastore.DatastoreSession;
 
 public class EqualsMethod<Entity> implements ProxyMethod<Entity> {
 
-    private InstanceManager<?, Entity> instanceManager;
+    private final InstanceManager<?, Entity> instanceManager;
 
-    private DatastoreSession<?, Entity, ?, ?, ?, ?> datastoreSession;
+    private final DatastoreSession<?, Entity, ?, ?, ?, ?> datastoreSession;
 
     public EqualsMethod(InstanceManager<?, Entity> instanceManager, DatastoreSession<?, Entity, ?, ?, ?, ?> datastoreSession) {
         this.instanceManager = instanceManager;

--- a/impl/src/main/java/com/buschmais/cdo/impl/proxy/instance/object/HashCodeMethod.java
+++ b/impl/src/main/java/com/buschmais/cdo/impl/proxy/instance/object/HashCodeMethod.java
@@ -5,7 +5,7 @@ import com.buschmais.cdo.api.proxy.ProxyMethod;
 
 public class HashCodeMethod<Entity> implements ProxyMethod<Entity> {
 
-    private DatastoreSession<?, Entity, ?, ?, ?, ?> datastoreSession;
+    private final DatastoreSession<?, Entity, ?, ?, ?, ?> datastoreSession;
 
     public HashCodeMethod(DatastoreSession<?, Entity,?, ?, ?, ?> datastoreSession) {
         this.datastoreSession = datastoreSession;

--- a/impl/src/main/java/com/buschmais/cdo/impl/proxy/instance/object/ToStringMethod.java
+++ b/impl/src/main/java/com/buschmais/cdo/impl/proxy/instance/object/ToStringMethod.java
@@ -5,7 +5,7 @@ import com.buschmais.cdo.api.proxy.ProxyMethod;
 
 public class ToStringMethod<Entity> implements ProxyMethod<Entity> {
 
-    private DatastoreSession<?, Entity,?, ?, ?, ?> datastoreSession;
+    private final DatastoreSession datastoreSession;
 
     public ToStringMethod(DatastoreSession datastoreSession) {
         this.datastoreSession = datastoreSession;
@@ -13,7 +13,7 @@ public class ToStringMethod<Entity> implements ProxyMethod<Entity> {
 
     @Override
     public Object invoke(Entity entity, Object instance, Object[] args) {
-        StringBuffer stringBuffer = new StringBuffer();
+        StringBuilder stringBuffer = new StringBuilder();
         for (Class<?> type : instance.getClass().getInterfaces()) {
             if (stringBuffer.length() > 0) {
                 stringBuffer.append('|');

--- a/impl/src/main/java/com/buschmais/cdo/impl/proxy/instance/property/AbstractPropertyMethod.java
+++ b/impl/src/main/java/com/buschmais/cdo/impl/proxy/instance/property/AbstractPropertyMethod.java
@@ -7,9 +7,9 @@ import com.buschmais.cdo.spi.metadata.AbstractMethodMetadata;
 
 public abstract class AbstractPropertyMethod<Entity, M extends AbstractMethodMetadata> implements ProxyMethod<Entity> {
 
-    private M metadata;
-    private InstanceManager<?, Entity> instanceManager;
-    private PropertyManager<?, Entity, ?, ?> propertyManager;
+    private final M metadata;
+    private final InstanceManager<?, Entity> instanceManager;
+    private final PropertyManager<?, Entity, ?, ?> propertyManager;
 
     protected AbstractPropertyMethod(M metadata, InstanceManager<?, Entity> instanceManager, PropertyManager<?, Entity, ?, ?> propertyManager) {
         this.metadata = metadata;

--- a/impl/src/main/java/com/buschmais/cdo/impl/proxy/instance/property/CollectionPropertyGetMethod.java
+++ b/impl/src/main/java/com/buschmais/cdo/impl/proxy/instance/property/CollectionPropertyGetMethod.java
@@ -15,7 +15,7 @@ import java.util.Set;
 
 public class CollectionPropertyGetMethod<Entity> extends AbstractPropertyMethod<Entity, CollectionPropertyMethodMetadata> {
 
-    private InterceptorFactory interceptorFactory;
+    private final InterceptorFactory interceptorFactory;
 
     public CollectionPropertyGetMethod(CollectionPropertyMethodMetadata<?> metadata, InstanceManager instanceManager, PropertyManager propertyManager, InterceptorFactory interceptorFactory) {
         super(metadata, instanceManager, propertyManager);

--- a/impl/src/main/java/com/buschmais/cdo/impl/proxy/instance/resultof/ResultOfMethod.java
+++ b/impl/src/main/java/com/buschmais/cdo/impl/proxy/instance/resultof/ResultOfMethod.java
@@ -15,11 +15,11 @@ import java.util.List;
 
 public class ResultOfMethod<Entity> implements ProxyMethod<Entity> {
 
-    private ResultOfMethodMetadata resultOfMethodMetadata;
-    private InstanceManager instanceManager;
-    private CdoTransaction cdoTransaction;
-    private InterceptorFactory interceptorFactory;
-    private DatastoreSession datastoreSession;
+    private final ResultOfMethodMetadata resultOfMethodMetadata;
+    private final InstanceManager instanceManager;
+    private final CdoTransaction cdoTransaction;
+    private final InterceptorFactory interceptorFactory;
+    private final DatastoreSession datastoreSession;
 
     public ResultOfMethod(ResultOfMethodMetadata resultOfMethodMetadata, InstanceManager instanceManager, CdoTransaction cdoTransaction, InterceptorFactory interceptorFactory, DatastoreSession datastoreSession) {
         this.resultOfMethodMetadata = resultOfMethodMetadata;

--- a/impl/src/main/java/com/buschmais/cdo/impl/proxy/query/RowInvocationHandler.java
+++ b/impl/src/main/java/com/buschmais/cdo/impl/proxy/query/RowInvocationHandler.java
@@ -6,9 +6,9 @@ import java.util.Map;
 
 public class RowInvocationHandler implements InvocationHandler {
 
-    private Map<String, Object> row;
+    private final Map<String, Object> row;
 
-    private RowProxyMethodService rowProxyMethodService;
+    private final RowProxyMethodService rowProxyMethodService;
 
     public RowInvocationHandler(Map<String, Object> row, RowProxyMethodService rowProxyMethodService) {
         this.row = row;

--- a/impl/src/main/java/com/buschmais/cdo/impl/proxy/query/property/GetMethod.java
+++ b/impl/src/main/java/com/buschmais/cdo/impl/proxy/query/property/GetMethod.java
@@ -7,8 +7,8 @@ import java.util.Map;
 
 public class GetMethod implements RowProxyMethod {
 
-    private String name;
-    private Class<?> type;
+    private final String name;
+    private final Class<?> type;
 
     public GetMethod(String name, Class<?> type) {
         this.name = name;

--- a/impl/src/main/java/com/buschmais/cdo/impl/query/QueryResultIterableImpl.java
+++ b/impl/src/main/java/com/buschmais/cdo/impl/query/QueryResultIterableImpl.java
@@ -13,11 +13,11 @@ import java.util.*;
 
 class QueryResultIterableImpl<T> extends AbstractResultIterable<T> implements Query.Result<T> {
 
-    private InstanceManager instanceManager;
-    private DatastoreSession datastoreSession;
-    private ResultIterator<Map<String, Object>> iterator;
-    private SortedSet<Class<?>> types;
-    private RowProxyMethodService rowProxyMethodService;
+    private final InstanceManager instanceManager;
+    private final DatastoreSession datastoreSession;
+    private final ResultIterator<Map<String, Object>> iterator;
+    private final SortedSet<Class<?>> types;
+    private final RowProxyMethodService rowProxyMethodService;
 
     QueryResultIterableImpl(InstanceManager instanceManager, DatastoreSession datastoreSession,
                             ResultIterator<Map<String, Object>> iterator, SortedSet<Class<?>> types) {
@@ -58,7 +58,7 @@ class QueryResultIterableImpl<T> extends AbstractResultIterable<T> implements Qu
 
             private Object decodeValue(Object value) {
                 if (value == null) {
-                    return value;
+                    return null;
                 }
                 Object decodedValue;
                 if (datastoreSession.isEntity(value)) {

--- a/impl/src/main/java/com/buschmais/cdo/impl/reflection/BeanMethodProvider.java
+++ b/impl/src/main/java/com/buschmais/cdo/impl/reflection/BeanMethodProvider.java
@@ -12,10 +12,10 @@ import java.util.*;
 
 public final class BeanMethodProvider {
 
-    private Set<Method> methods = new HashSet<>();
-    private Map<String, Method> getters = new HashMap<>();
-    private Map<String, Method> setters = new HashMap<>();
-    private Map<String, Class<?>> types = new HashMap<>();
+    private final Set<Method> methods = new HashSet<>();
+    private final Map<String, Method> getters = new HashMap<>();
+    private final Map<String, Method> setters = new HashMap<>();
+    private final Map<String, Class<?>> types = new HashMap<>();
 
     private BeanMethodProvider() {
     }

--- a/impl/src/main/java/com/buschmais/cdo/impl/validation/ValidatorSynchronization.java
+++ b/impl/src/main/java/com/buschmais/cdo/impl/validation/ValidatorSynchronization.java
@@ -8,7 +8,7 @@ import java.util.Set;
 
 public class ValidatorSynchronization implements CdoTransaction.Synchronization{
 
-    private InstanceValidator instanceValidator;
+    private final InstanceValidator instanceValidator;
 
     public ValidatorSynchronization(InstanceValidator instanceValidator) {
         this.instanceValidator = instanceValidator;

--- a/impl/src/test/java/com/buschmais/cdo/impl/test/bootstrap/provider/TestCdoDatastore.java
+++ b/impl/src/test/java/com/buschmais/cdo/impl/test/bootstrap/provider/TestCdoDatastore.java
@@ -14,7 +14,7 @@ import java.util.Map;
 
 public class TestCdoDatastore<D extends DatastoreSession> implements Datastore<D, TestEntityMetadata, String> {
 
-    private CdoUnit cdoUnit;
+    private final CdoUnit cdoUnit;
 
     public TestCdoDatastore(CdoUnit cdoUnit) {
         this.cdoUnit = cdoUnit;

--- a/impl/src/test/java/com/buschmais/cdo/impl/test/bootstrap/provider/metadata/TestEntityMetadata.java
+++ b/impl/src/test/java/com/buschmais/cdo/impl/test/bootstrap/provider/metadata/TestEntityMetadata.java
@@ -4,7 +4,7 @@ import com.buschmais.cdo.spi.datastore.DatastoreEntityMetadata;
 
 public class TestEntityMetadata implements DatastoreEntityMetadata<String> {
 
-    private String type;
+    private final String type;
 
     public TestEntityMetadata(String type) {
         this.type = type;

--- a/json/src/main/java/com/buschmais/cdo/store/json/impl/JsonFileStore.java
+++ b/json/src/main/java/com/buschmais/cdo/store/json/impl/JsonFileStore.java
@@ -10,7 +10,7 @@ import java.util.Collection;
 
 public class JsonFileStore implements Datastore<JsonFileStoreSession, JsonNodeMetadata, String> {
 
-    private File directory;
+    private final File directory;
 
     public JsonFileStore(String directory) {
         this.directory = new File(directory);

--- a/json/src/main/java/com/buschmais/cdo/store/json/impl/JsonFileStoreSession.java
+++ b/json/src/main/java/com/buschmais/cdo/store/json/impl/JsonFileStoreSession.java
@@ -26,9 +26,9 @@ public class JsonFileStoreSession implements DatastoreSession<UUID, ObjectNode, 
     private static final String ID_PROPERTY = "id";
     private static final String TYPES_PROPERTY = "types";
 
-    private ObjectMapper mapper = new ObjectMapper();
+    private final ObjectMapper mapper = new ObjectMapper();
 
-    private File directory;
+    private final File directory;
 
     public JsonFileStoreSession(File directory) {
         this.directory = directory;

--- a/json/src/main/java/com/buschmais/cdo/store/json/impl/metadata/JsonNodeMetadata.java
+++ b/json/src/main/java/com/buschmais/cdo/store/json/impl/metadata/JsonNodeMetadata.java
@@ -6,7 +6,7 @@ import java.util.Collection;
 
 public class JsonNodeMetadata implements DatastoreEntityMetadata<String> {
 
-    private String discriminator;
+    private final String discriminator;
 
     public JsonNodeMetadata(String discriminator) {
         this.discriminator = discriminator;

--- a/neo4j/src/main/java/com/buschmais/cdo/neo4j/impl/datastore/AbstractNeo4jDatastore.java
+++ b/neo4j/src/main/java/com/buschmais/cdo/neo4j/impl/datastore/AbstractNeo4jDatastore.java
@@ -7,7 +7,7 @@ import org.neo4j.graphdb.Label;
 
 public abstract class AbstractNeo4jDatastore<DS extends AbstractNeo4jDatastoreSession> implements Datastore<DS, NodeMetadata, Label> {
 
-    private Neo4jMetadataFactory metadataFactory = new Neo4jMetadataFactory();
+    private final Neo4jMetadataFactory metadataFactory = new Neo4jMetadataFactory();
 
     @Override
     public DatastoreMetadataFactory<NodeMetadata, Label> getMetadataFactory() {

--- a/neo4j/src/main/java/com/buschmais/cdo/neo4j/impl/datastore/AbstractNeo4jDatastoreSession.java
+++ b/neo4j/src/main/java/com/buschmais/cdo/neo4j/impl/datastore/AbstractNeo4jDatastoreSession.java
@@ -18,8 +18,8 @@ import java.util.Set;
 
 public abstract class AbstractNeo4jDatastoreSession<GDS extends GraphDatabaseService> implements DatastoreSession<Long, Node, NodeMetadata, Label, Long, Relationship> {
 
-    private GDS graphDatabaseService;
-    private Neo4jPropertyManager propertyManager;
+    private final GDS graphDatabaseService;
+    private final Neo4jPropertyManager propertyManager;
 
     public AbstractNeo4jDatastoreSession(GDS graphDatabaseService) {
         this.graphDatabaseService = graphDatabaseService;

--- a/neo4j/src/main/java/com/buschmais/cdo/neo4j/impl/datastore/ResourceResultIterator.java
+++ b/neo4j/src/main/java/com/buschmais/cdo/neo4j/impl/datastore/ResourceResultIterator.java
@@ -8,7 +8,7 @@ import org.neo4j.graphdb.ResourceIterator;
 */
 final class ResourceResultIterator<T> implements ResultIterator<T> {
 
-    private ResourceIterator<T> iterator;
+    private final ResourceIterator<T> iterator;
 
     ResourceResultIterator(ResourceIterator<T> iterator) {
         this.iterator = iterator;

--- a/neo4j/src/main/java/com/buschmais/cdo/neo4j/impl/datastore/RestNeo4jDatastore.java
+++ b/neo4j/src/main/java/com/buschmais/cdo/neo4j/impl/datastore/RestNeo4jDatastore.java
@@ -8,7 +8,7 @@ import java.util.Collection;
 
 public class RestNeo4jDatastore extends  AbstractNeo4jDatastore<RestNeo4jDatastoreSession> {
 
-    private String url;
+    private final String url;
 
     public RestNeo4jDatastore(String url) {
         this.url = url;

--- a/neo4j/src/main/java/com/buschmais/cdo/neo4j/impl/datastore/metadata/NodeMetadata.java
+++ b/neo4j/src/main/java/com/buschmais/cdo/neo4j/impl/datastore/metadata/NodeMetadata.java
@@ -6,9 +6,9 @@ import org.neo4j.graphdb.Label;
 
 public class NodeMetadata implements DatastoreEntityMetadata<Label> {
 
-    private Label label;
+    private final Label label;
 
-    private IndexedPropertyMethodMetadata<?> indexedProperty;
+    private final IndexedPropertyMethodMetadata<?> indexedProperty;
 
     public NodeMetadata(Label label, IndexedPropertyMethodMetadata<?> indexedProperty) {
         this.label = label;

--- a/neo4j/src/main/java/com/buschmais/cdo/neo4j/impl/datastore/metadata/PrimitivePropertyMetadata.java
+++ b/neo4j/src/main/java/com/buschmais/cdo/neo4j/impl/datastore/metadata/PrimitivePropertyMetadata.java
@@ -2,7 +2,7 @@ package com.buschmais.cdo.neo4j.impl.datastore.metadata;
 
 public class PrimitivePropertyMetadata {
 
-    private String name;
+    private final String name;
 
     public PrimitivePropertyMetadata(String name) {
         this.name = name;

--- a/neo4j/src/main/java/com/buschmais/cdo/neo4j/impl/datastore/metadata/RelationshipMetadata.java
+++ b/neo4j/src/main/java/com/buschmais/cdo/neo4j/impl/datastore/metadata/RelationshipMetadata.java
@@ -4,7 +4,7 @@ import org.neo4j.graphdb.RelationshipType;
 
 public class RelationshipMetadata {
 
-    private RelationshipType relationshipType;
+    private final RelationshipType relationshipType;
 
     public RelationshipMetadata(RelationshipType relationshipType) {
         this.relationshipType = relationshipType;

--- a/neo4j/src/test/java/com/buschmais/cdo/neo4j/test/AbstractCdoManagerTest.java
+++ b/neo4j/src/test/java/com/buschmais/cdo/neo4j/test/AbstractCdoManagerTest.java
@@ -106,7 +106,7 @@ public abstract class AbstractCdoManagerTest {
      */
     protected class TestResult {
 
-        private Map<String, List<Object>> columns;
+        private final Map<String, List<Object>> columns;
 
         TestResult(Map<String, List<Object>> columns) {
             this.columns = columns;

--- a/spi/src/main/java/com/buschmais/cdo/spi/metadata/AbstractMetadata.java
+++ b/spi/src/main/java/com/buschmais/cdo/spi/metadata/AbstractMetadata.java
@@ -6,13 +6,13 @@ import java.util.Collection;
 
 public abstract class AbstractMetadata<S extends AbstractMetadata, DatastoreMetadata> {
 
-    private AnnotatedType annotatedType;
+    private final AnnotatedType annotatedType;
 
-    private Collection<AbstractMethodMetadata> properties;
+    private final Collection<AbstractMethodMetadata> properties;
 
-    private Collection<S> superTypes;
+    private final Collection<S> superTypes;
 
-    private DatastoreMetadata datastoreMetadata;
+    private final DatastoreMetadata datastoreMetadata;
 
     protected AbstractMetadata(AnnotatedType annotatedType, Collection<S> superTypes, Collection<AbstractMethodMetadata> properties, DatastoreMetadata datastoreMetadata) {
         this.annotatedType = annotatedType;

--- a/spi/src/main/java/com/buschmais/cdo/spi/metadata/AbstractMethodMetadata.java
+++ b/spi/src/main/java/com/buschmais/cdo/spi/metadata/AbstractMethodMetadata.java
@@ -4,9 +4,9 @@ import com.buschmais.cdo.spi.reflection.AnnotatedMethod;
 
 public abstract class AbstractMethodMetadata<B extends AnnotatedMethod, DatastoreMetadata> {
 
-    private B annotatedMethod;
+    private final B annotatedMethod;
 
-    private DatastoreMetadata datastoreMetadata;
+    private final DatastoreMetadata datastoreMetadata;
 
     protected AbstractMethodMetadata(B annotatedMethod, DatastoreMetadata datastoreMetadata) {
         this.annotatedMethod = annotatedMethod;

--- a/spi/src/main/java/com/buschmais/cdo/spi/metadata/AbstractRelationPropertyMethodMetadata.java
+++ b/spi/src/main/java/com/buschmais/cdo/spi/metadata/AbstractRelationPropertyMethodMetadata.java
@@ -6,9 +6,9 @@ import static com.buschmais.cdo.spi.metadata.RelationMetadata.Direction;
 
 public abstract class AbstractRelationPropertyMethodMetadata<DatastoreMetadata> extends AbstractPropertyMethodMetadata<DatastoreMetadata> {
 
-    private RelationMetadata relationMetadata;
+    private final RelationMetadata relationMetadata;
 
-    private Direction direction;
+    private final Direction direction;
 
     public AbstractRelationPropertyMethodMetadata(PropertyMethod propertyMethod, RelationMetadata relationMetadata, Direction direction, DatastoreMetadata datastoreMetadata) {
         super(propertyMethod, datastoreMetadata);

--- a/spi/src/main/java/com/buschmais/cdo/spi/metadata/EnumPropertyMethodMetadata.java
+++ b/spi/src/main/java/com/buschmais/cdo/spi/metadata/EnumPropertyMethodMetadata.java
@@ -5,7 +5,7 @@ import com.buschmais.cdo.spi.reflection.PropertyMethod;
 
 public class EnumPropertyMethodMetadata<DatastoreMetadata> extends AbstractPropertyMethodMetadata<DatastoreMetadata> {
 
-    private Class<? extends Enum<?>> enumerationType;
+    private final Class<? extends Enum<?>> enumerationType;
 
     public EnumPropertyMethodMetadata(PropertyMethod propertyMethod, Class<? extends Enum<?>> enumerationType, DatastoreMetadata datastoreMetadata) {
         super(propertyMethod, datastoreMetadata);

--- a/spi/src/main/java/com/buschmais/cdo/spi/metadata/ImplementedByMethodMetadata.java
+++ b/spi/src/main/java/com/buschmais/cdo/spi/metadata/ImplementedByMethodMetadata.java
@@ -5,7 +5,7 @@ import com.buschmais.cdo.spi.reflection.AnnotatedMethod;
 
 public class ImplementedByMethodMetadata<DatastoreMetadata> extends AbstractMethodMetadata<AnnotatedMethod, DatastoreMetadata> {
 
-    private Class<? extends ProxyMethod<?>> proxyMethodType;
+    private final Class<? extends ProxyMethod<?>> proxyMethodType;
 
     public ImplementedByMethodMetadata(AnnotatedMethod annotatedMethod, Class<? extends ProxyMethod<?>> proxyMethodType, DatastoreMetadata datastoreMetadata) {
         super(annotatedMethod, datastoreMetadata);

--- a/spi/src/main/java/com/buschmais/cdo/spi/metadata/IndexedPropertyMethodMetadata.java
+++ b/spi/src/main/java/com/buschmais/cdo/spi/metadata/IndexedPropertyMethodMetadata.java
@@ -4,7 +4,7 @@ import com.buschmais.cdo.spi.reflection.PropertyMethod;
 
 public class IndexedPropertyMethodMetadata<DatastoreMetadata> extends AbstractPropertyMethodMetadata<DatastoreMetadata> {
 
-    private PrimitivePropertyMethodMetadata propertyMethodMetadata;
+    private final PrimitivePropertyMethodMetadata propertyMethodMetadata;
 
     public IndexedPropertyMethodMetadata(PropertyMethod propertyMethod, PrimitivePropertyMethodMetadata propertyMethodMetadata, DatastoreMetadata datastoreMetadata) {
         super(propertyMethod, datastoreMetadata);

--- a/spi/src/main/java/com/buschmais/cdo/spi/metadata/ResultOfMethodMetadata.java
+++ b/spi/src/main/java/com/buschmais/cdo/spi/metadata/ResultOfMethodMetadata.java
@@ -7,13 +7,13 @@ import java.util.List;
 
 public class ResultOfMethodMetadata<DatastoreMetadata> extends AbstractMethodMetadata<AnnotatedMethod, DatastoreMetadata> {
 
-    private Class<?> query;
+    private final Class<?> query;
 
-    private String usingThisAs;
+    private final String usingThisAs;
 
-    private List<ResultOf.Parameter> parameters;
+    private final List<ResultOf.Parameter> parameters;
 
-    private boolean singleResult;
+    private final boolean singleResult;
 
     public ResultOfMethodMetadata(AnnotatedMethod annotatedMethod, Class<?> query, String usingThisAs, List<ResultOf.Parameter> parameters, boolean singleResult) {
         super(annotatedMethod, null);

--- a/spi/src/main/java/com/buschmais/cdo/spi/metadata/TypeMetadata.java
+++ b/spi/src/main/java/com/buschmais/cdo/spi/metadata/TypeMetadata.java
@@ -7,7 +7,7 @@ import java.util.Collection;
 
 public class TypeMetadata<DatastoreMetadata extends DatastoreEntityMetadata<?>> extends AbstractMetadata<TypeMetadata<DatastoreMetadata>, DatastoreMetadata> {
 
-    private IndexedPropertyMethodMetadata indexedProperty;
+    private final IndexedPropertyMethodMetadata indexedProperty;
 
     public TypeMetadata(AnnotatedType annotatedType, Collection<TypeMetadata<DatastoreMetadata>> superTypeMetadatas, Collection<AbstractMethodMetadata> methodMetadatas, IndexedPropertyMethodMetadata indexedProperty, DatastoreMetadata datastoreMetadata) {
         super(annotatedType, superTypeMetadatas, methodMetadatas, datastoreMetadata);

--- a/spi/src/main/java/com/buschmais/cdo/spi/reflection/AbstractAnnotatedElement.java
+++ b/spi/src/main/java/com/buschmais/cdo/spi/reflection/AbstractAnnotatedElement.java
@@ -9,7 +9,7 @@ import java.lang.annotation.Annotation;
  */
 public class AbstractAnnotatedElement<AE extends java.lang.reflect.AnnotatedElement> implements AnnotatedElement<AE> {
 
-    private AE annotated;
+    private final AE annotated;
 
     /**
      * Constructor.

--- a/spi/src/main/java/com/buschmais/cdo/spi/reflection/SetPropertyMethod.java
+++ b/spi/src/main/java/com/buschmais/cdo/spi/reflection/SetPropertyMethod.java
@@ -8,7 +8,7 @@ import java.lang.reflect.Method;
  */
 public class SetPropertyMethod extends AbstractPropertyMethod {
 
-    private GetPropertyMethod getter;
+    private final GetPropertyMethod getter;
 
     /**
      * Constructor.


### PR DESCRIPTION
make fields final
try reduce generics-warnings   

TODO:  
- do we need that much generics-hell??
- we should rename generics-parameters to upper-case  read here: [docs.oracle](http://docs.oracle.com/javase/tutorial/java/generics/types.html)
  `class Foo<MetaData> {`  should be  `class Foo<METADATA> {`
