### PR TITLE
#75 - bound build-helper-plugin to earlier lifecycle phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
                 <executions>
                     <execution>
                         <id>set-osgi-version</id>
-                        <phase>verify</phase>
+                        <phase>validate</phase>
                         <goals>
                             <goal>parse-version</goal>
                         </goals>
@@ -108,7 +108,7 @@
                         <id>attach-sources</id>
                         <phase>verify</phase>
                         <goals>
-                            <goal>jar</goal>
+                            <goal>jar-no-fork</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
Source bundles at Maven Central contain wrong headers.

```
Eclipse-SourceBundle: com.buschmais.cdo.api;version="${parsedVersion.o
 sgiVersion}";roots:="."
Bundle-Version: 
```
